### PR TITLE
fix the error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ version = "0.1.0"
 description = "A package with functions created to clean survey data with a focus on text input."
 authors = [
     { name = "Natalie Truesdell", email = "natalieetruesdell@gmail.com" },
-    { name = "Amanpreet Binepal, email = "binepal2003@gmail.com" },
+    { name = "Amanpreet Binepal", email = "binepal2003@gmail.com" },
     { name = "Yusheng Li", email = "lyusheng0606@gmail.com"},
     { name = "Junli Liu", email = "liujunli1001@gmail.com"}
 ]


### PR DESCRIPTION
Fix: Correct syntax error in the author field of pyproject.toml

File: pyproject.toml (1 file)

Change summary:
- Fixed a syntax error on line 21.

Details:
- Original line:
  { name = "Amanpreet Binepal, email = "binepal2003@gmail.com" },
  
- Updated line:
  { name = "Amanpreet Binepal", email = "binepal2003@gmail.com" },

Issue:
- Missing closing quote after the author's name caused invalid TOML syntax.

Impact:
- This syntax error prevents commands like `pip install` and `pytest` from running correctly.