### PR TITLE
[Peer Feedback] - Added version and exports in __init__.py

### DIFF
--- a/src/survey_cleaner/__init__.py
+++ b/src/survey_cleaner/__init__.py
@@ -38,3 +38,12 @@ remove_duplicates : Keep only latest survey response from user
 
 __version__ = "1.0.0"
 
+from .word_to_ordinal import word_to_ordinal
+from .handle_emptyStrings import handle_emptyStrings
+from .normalize_binary import normalize_binary
+from .remove_duplicates import remove_duplicates
+
+__all__ = ['word_to_ordinal',
+            'handle_emptyStrings',
+              'normalize_binary',
+                'remove_duplicates']


### PR DESCRIPTION
## Change

- [ ] Add all functions to `__init__.py` to simplify import syntax matching the documentation syntax

## Solves

- [ ] Previously we had to import our functions verbosely which does not match our documentation, now user can import functions with the syntax written in the documentation

## Related Issue
#67 

## Regarding Previous Pull Request

- [ ] Added version tag to the __init__.py as it was failing before without
- [ ] Readded the exports to __init__.py as it wasn't successfully pushed in previous push due to failed job
